### PR TITLE
Register full mirrored jars with their network once.

### DIFF
--- a/src/main/java/makeo/gadomancy/common/blocks/tiles/TileRemoteJar.java
+++ b/src/main/java/makeo/gadomancy/common/blocks/tiles/TileRemoteJar.java
@@ -26,14 +26,17 @@ public class TileRemoteJar extends TileJarFillable {
 
     private int count = 0;
 
+    private boolean registered_to_network = false;
+
     @Override
     public void updateEntity() {
         super.updateEntity();
-        if (count % 3 == 0 && !getWorldObj().isRemote && networkId != null && amount < maxAmount) {
+        if (count % 3 == 0 && !getWorldObj().isRemote && networkId != null && (!registered_to_network || amount < maxAmount)) {
             count = 0;
 
             JarNetwork network = getNetwork(networkId);
 
+            registered_to_network = true;
             if(!network.jars.contains(this)) {
                 network.jars.add((TileJarFillable) worldObj.getTileEntity(xCoord, yCoord, zCoord));
             }


### PR DESCRIPTION
Currently, full mirrored jars will never register themselves with their
network, meaning that if the server is restarted while a full mirrored
jar is in the world (or if a player places a full mirrored jar for the
first time since the server has started), the jar will be unable to
share essentia with the rest of its network.

This adds a check to register the jar even if it is full. The performance
impact should be minimal since we only check each jar once per run.